### PR TITLE
[BE] Wystawienie możliwości dodawania do bazy danych posiłków przypisanych do firmy kateringowej

### DIFF
--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/company/domain/CateringCompanyRepository.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/company/domain/CateringCompanyRepository.java
@@ -1,7 +1,9 @@
 package org.caterly.cateringcompanyservice.company.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CateringCompanyRepository
         extends JpaRepository<CateringCompanyEntity, Long> {
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/company/domain/CateringCompanyRepository.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/company/domain/CateringCompanyRepository.java
@@ -2,5 +2,6 @@ package org.caterly.cateringcompanyservice.company.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CateringCompanyRepository extends JpaRepository<CateringCompanyEntity, Long> {
+public interface CateringCompanyRepository
+        extends JpaRepository<CateringCompanyEntity, Long> {
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/company/domain/CateringCompanyRepository.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/company/domain/CateringCompanyRepository.java
@@ -1,0 +1,6 @@
+package org.caterly.cateringcompanyservice.company.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CateringCompanyRepository extends JpaRepository<CateringCompanyEntity, Long> {
+}

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/CateringOfferController.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/CateringOfferController.java
@@ -5,7 +5,12 @@ import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferDTO;
 import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferRequestDTO;
 import org.caterly.cateringcompanyservice.offer.application.CateringOfferService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -26,7 +31,9 @@ public final class CateringOfferController {
     }
 
     @PostMapping("")
-    public ResponseEntity<CateringOfferDTO> postCateringOffer(@RequestBody CateringOfferRequestDTO requestBody) {
+    public ResponseEntity<CateringOfferDTO> postCateringOffer(
+            final @RequestBody CateringOfferRequestDTO requestBody
+    ) {
         return ResponseEntity.ok(cateringOfferService.add(requestBody));
     }
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/CateringOfferController.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/CateringOfferController.java
@@ -2,12 +2,10 @@ package org.caterly.cateringcompanyservice.offer.api;
 
 import lombok.RequiredArgsConstructor;
 import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferDTO;
+import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferRequestDTO;
 import org.caterly.cateringcompanyservice.offer.application.CateringOfferService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -25,5 +23,10 @@ public final class CateringOfferController {
         return ResponseEntity.ok(
             cateringOfferService.getAllOffers(cateringCompanyId)
         );
+    }
+
+    @PostMapping("")
+    public ResponseEntity<CateringOfferDTO> postCateringOffer(@RequestBody CateringOfferRequestDTO requestBody) {
+        return ResponseEntity.ok(cateringOfferService.add(requestBody));
     }
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/CateringOfferController.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/CateringOfferController.java
@@ -30,7 +30,7 @@ public final class CateringOfferController {
         );
     }
 
-    @PostMapping("")
+    @PostMapping
     public ResponseEntity<CateringOfferDTO> postCateringOffer(
             final @RequestBody CateringOfferRequestDTO requestBody
     ) {

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferDTO.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferDTO.java
@@ -7,5 +7,9 @@ public class CateringOfferDTO {
     private Long id;
     private Double price;
     private String typeOfFood;
-    private byte[] picture;
+    private Byte[] picture;
+
+    public final Byte[] getPicture() {
+        return picture.clone();
+    }
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferDTO.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferDTO.java
@@ -7,9 +7,5 @@ public class CateringOfferDTO {
     private Long id;
     private Double price;
     private String typeOfFood;
-    private byte[] picture;
-
-    public final byte[] getPicture() {
-        return picture.clone();
-    }
+    private String picture;
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferDTO.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferDTO.java
@@ -7,9 +7,9 @@ public class CateringOfferDTO {
     private Long id;
     private Double price;
     private String typeOfFood;
-    private Byte[] picture;
+    private byte[] picture;
 
-    public final Byte[] getPicture() {
+    public final byte[] getPicture() {
         return picture.clone();
     }
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferRequestDTO.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferRequestDTO.java
@@ -3,9 +3,9 @@ package org.caterly.cateringcompanyservice.offer.api.dto;
 import lombok.Data;
 
 @Data
-public class CateringOfferDTO {
-    private Long id;
+public class CateringOfferRequestDTO {
     private Double price;
     private String typeOfFood;
     private byte[] picture;
+    private long companyId;
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferRequestDTO.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferRequestDTO.java
@@ -6,10 +6,10 @@ import lombok.Data;
 public class CateringOfferRequestDTO {
     private Double price;
     private String typeOfFood;
-    private Byte[] picture;
+    private byte[] picture;
     private Long companyId;
 
-    public final Byte[] getPicture() {
+    public final byte[] getPicture() {
         return picture.clone();
     }
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferRequestDTO.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferRequestDTO.java
@@ -6,6 +6,10 @@ import lombok.Data;
 public class CateringOfferRequestDTO {
     private Double price;
     private String typeOfFood;
-    private byte[] picture;
-    private long companyId;
+    private Byte[] picture;
+    private Long companyId;
+
+    public final Byte[] getPicture() {
+        return picture.clone();
+    }
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferRequestDTO.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/api/dto/CateringOfferRequestDTO.java
@@ -6,10 +6,6 @@ import lombok.Data;
 public class CateringOfferRequestDTO {
     private Double price;
     private String typeOfFood;
-    private byte[] picture;
+    private String picture;
     private Long companyId;
-
-    public final byte[] getPicture() {
-        return picture.clone();
-    }
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/application/CateringOfferService.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/application/CateringOfferService.java
@@ -1,9 +1,11 @@
 package org.caterly.cateringcompanyservice.offer.application;
 
 import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferDTO;
+import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferRequestDTO;
 
 import java.util.List;
 
 public interface CateringOfferService {
     List<CateringOfferDTO> getAllOffers(long request);
+    CateringOfferDTO add(CateringOfferRequestDTO request);
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
@@ -1,6 +1,12 @@
 package org.caterly.cateringcompanyservice.offer.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
@@ -32,9 +32,9 @@ public final class CateringFoodEntity {
 
     private String typeOfFood;
 
-    private Byte[] picture;
+    private byte[] picture;
 
-    public Byte[] getPicture() {
+    public byte[] getPicture() {
         return picture.clone();
     }
 

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
@@ -32,11 +32,7 @@ public final class CateringFoodEntity {
 
     private String typeOfFood;
 
-    private byte[] picture;
-
-    public byte[] getPicture() {
-        return picture.clone();
-    }
+    private String picture;
 
     @ManyToOne
     @JoinColumn(name = "catering_company_id", nullable = false)

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
@@ -32,7 +32,11 @@ public final class CateringFoodEntity {
 
     private String typeOfFood;
 
-    private byte[] picture;
+    private Byte[] picture;
+
+    public Byte[] getPicture() {
+        return picture.clone();
+    }
 
     @ManyToOne
     @JoinColumn(name = "catering_company_id", nullable = false)

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
@@ -1,8 +1,6 @@
 package org.caterly.cateringcompanyservice.offer.domain;
 
-import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Null;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringFoodEntity.java
@@ -1,12 +1,8 @@
 package org.caterly.cateringcompanyservice.offer.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Null;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,8 +23,12 @@ public final class CateringFoodEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private double price;
+
     private String typeOfFood;
+
+    private byte[] picture;
 
     @ManyToOne
     @JoinColumn(name = "catering_company_id", nullable = false)

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferRepository.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferRepository.java
@@ -2,9 +2,11 @@ package org.caterly.cateringcompanyservice.offer.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 interface CateringOfferRepository
     extends JpaRepository<CateringFoodEntity, Long> {
     @Query(value = "SELECT * FROM catering_food_entity "

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImpl.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImpl.java
@@ -26,7 +26,7 @@ public final class CateringOfferServiceImpl implements CateringOfferService {
     }
 
     @Override
-    public CateringOfferDTO add(CateringOfferRequestDTO request) {
+    public CateringOfferDTO add(final CateringOfferRequestDTO request) {
         CateringFoodEntity entity = offerMapper.toCateringFoodEntity(request);
         cateringOfferRepository.saveAndFlush(entity);
         return offerMapper.toCateringOfferDTO(entity);

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImpl.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImpl.java
@@ -27,8 +27,9 @@ public final class CateringOfferServiceImpl implements CateringOfferService {
 
     @Override
     public CateringOfferDTO add(final CateringOfferRequestDTO request) {
-        CateringFoodEntity entity = offerMapper.toCateringFoodEntity(request);
-        cateringOfferRepository.saveAndFlush(entity);
+        CateringFoodEntity entity = cateringOfferRepository.save(
+                offerMapper.toCateringFoodEntity(request)
+        );
         return offerMapper.toCateringOfferDTO(entity);
     }
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImpl.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImpl.java
@@ -2,6 +2,7 @@ package org.caterly.cateringcompanyservice.offer.domain;
 
 import lombok.RequiredArgsConstructor;
 import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferDTO;
+import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferRequestDTO;
 import org.caterly.cateringcompanyservice.offer.application.CateringOfferService;
 import org.caterly.cateringcompanyservice.offer.mapper.OfferMapper;
 import org.springframework.stereotype.Service;
@@ -22,5 +23,12 @@ public final class CateringOfferServiceImpl implements CateringOfferService {
         return cateringOfferRepository.findAllByCompanyId(cateringCompanyId)
                 .stream()
                 .map(offerMapper::toCateringOfferDTO).toList();
+    }
+
+    @Override
+    public CateringOfferDTO add(CateringOfferRequestDTO request) {
+        CateringFoodEntity entity = offerMapper.toCateringFoodEntity(request);
+        cateringOfferRepository.saveAndFlush(entity);
+        return offerMapper.toCateringOfferDTO(entity);
     }
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/mapper/OfferMapper.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/mapper/OfferMapper.java
@@ -1,11 +1,30 @@
 package org.caterly.cateringcompanyservice.offer.mapper;
 
+import org.caterly.cateringcompanyservice.company.domain.CateringCompanyEntity;
+import org.caterly.cateringcompanyservice.company.domain.CateringCompanyRepository;
 import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferDTO;
+import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferRequestDTO;
 import org.caterly.cateringcompanyservice.offer.domain.CateringFoodEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
-public interface OfferMapper {
-    CateringOfferDTO toCateringOfferDTO(CateringFoodEntity cateringFoodEntity);
+public abstract class OfferMapper {
+    @Autowired
+    private CateringCompanyRepository cateringCompanyRepository;
+
+    public CateringCompanyEntity resolveCateringCompanyEntity(Long companyId) {
+        if (companyId == null) {
+            return null;
+        }
+        return cateringCompanyRepository.getById(companyId);
+    }
+
+    public abstract CateringOfferDTO toCateringOfferDTO(CateringFoodEntity cateringFoodEntity);
+
+    @Mapping(target = "company", source = "companyId")
+    @Mapping(target = "id", ignore = true)
+    public abstract CateringFoodEntity toCateringFoodEntity(CateringOfferRequestDTO cateringOfferRequestDTO);
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/mapper/OfferMapper.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/mapper/OfferMapper.java
@@ -15,19 +15,22 @@ public abstract class OfferMapper {
     @Autowired
     private CateringCompanyRepository cateringCompanyRepository;
 
+    public abstract CateringOfferDTO toCateringOfferDTO(
+            CateringFoodEntity cateringFoodEntity
+    );
 
-    public final CateringCompanyEntity resolveCateringCompanyEntity(final Long companyId) {
+    @Mapping(target = "company", source = "companyId")
+    @Mapping(target = "id", ignore = true)
+    public abstract CateringFoodEntity toCateringFoodEntity(
+            CateringOfferRequestDTO cateringOfferRequestDTO
+    );
+    
+    public final CateringCompanyEntity resolveCateringCompanyEntity(
+            final Long companyId
+    ) {
         if (companyId == null) {
             return null;
         }
         return cateringCompanyRepository.getById(companyId);
     }
-
-    public abstract CateringOfferDTO
-                    toCateringOfferDTO(CateringFoodEntity cateringFoodEntity);
-
-    @Mapping(target = "company", source = "companyId")
-    @Mapping(target = "id", ignore = true)
-    public abstract CateringFoodEntity
-                    toCateringFoodEntity(CateringOfferRequestDTO cateringOfferRequestDTO);
 }

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/mapper/OfferMapper.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/mapper/OfferMapper.java
@@ -24,7 +24,7 @@ public abstract class OfferMapper {
     public abstract CateringFoodEntity toCateringFoodEntity(
             CateringOfferRequestDTO cateringOfferRequestDTO
     );
-    
+
     public final CateringCompanyEntity resolveCateringCompanyEntity(
             final Long companyId
     ) {

--- a/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/mapper/OfferMapper.java
+++ b/backend/cateringCompanyService/src/main/java/org/caterly/cateringcompanyservice/offer/mapper/OfferMapper.java
@@ -15,16 +15,19 @@ public abstract class OfferMapper {
     @Autowired
     private CateringCompanyRepository cateringCompanyRepository;
 
-    public CateringCompanyEntity resolveCateringCompanyEntity(Long companyId) {
+
+    public final CateringCompanyEntity resolveCateringCompanyEntity(final Long companyId) {
         if (companyId == null) {
             return null;
         }
         return cateringCompanyRepository.getById(companyId);
     }
 
-    public abstract CateringOfferDTO toCateringOfferDTO(CateringFoodEntity cateringFoodEntity);
+    public abstract CateringOfferDTO
+                    toCateringOfferDTO(CateringFoodEntity cateringFoodEntity);
 
     @Mapping(target = "company", source = "companyId")
     @Mapping(target = "id", ignore = true)
-    public abstract CateringFoodEntity toCateringFoodEntity(CateringOfferRequestDTO cateringOfferRequestDTO);
+    public abstract CateringFoodEntity
+                    toCateringFoodEntity(CateringOfferRequestDTO cateringOfferRequestDTO);
 }

--- a/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferRepositoryTest.java
+++ b/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferRepositoryTest.java
@@ -7,11 +7,14 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 import java.util.List;
+import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 class CateringOfferRepositoryTest {
+    private static final int PICTURE_ARRAY_SIZE = 5;
+    private final Random random = new Random();
 
     @Autowired
     private CateringOfferRepository cateringOfferRepository;
@@ -27,19 +30,23 @@ class CateringOfferRepositoryTest {
         company = entityManager.persistAndFlush(company);
 
         final double offer1Price = 12.99;
+        final byte[] offer1Picture = new byte[PICTURE_ARRAY_SIZE];
+        random.nextBytes(offer1Picture);
         CateringFoodEntity offer1 = new CateringFoodEntity();
         offer1.setCompany(company);
         offer1.setPrice(offer1Price);
         offer1.setTypeOfFood("Pizza");
-        offer1.setPicture(new byte[] { 0x00, 0x56, 0x24, -0x61 });
+        offer1.setPicture(offer1Picture);
         entityManager.persist(offer1);
 
         final double offer2Price = 10.99;
+        final byte[] offer2Picture = new byte[PICTURE_ARRAY_SIZE];
+        random.nextBytes(offer2Picture);
         CateringFoodEntity offer2 = new CateringFoodEntity();
         offer2.setCompany(company);
         offer2.setPrice(offer2Price);
         offer2.setTypeOfFood("Burger");
-        offer2.setPicture(new byte[] { 0x26, -0x12, -0x5F, 0x7F });
+        offer2.setPicture(offer2Picture);
         entityManager.persist(offer2);
 
         // Another company with a different offer
@@ -48,11 +55,13 @@ class CateringOfferRepositoryTest {
         otherCompany = entityManager.persistAndFlush(otherCompany);
 
         final double otherOfferPrice = 8.99;
+        final byte[] otherOfferPicture = new byte[PICTURE_ARRAY_SIZE];
+        random.nextBytes(otherOfferPicture);
         CateringFoodEntity otherOffer = new CateringFoodEntity();
         otherOffer.setCompany(otherCompany);
         otherOffer.setPrice(otherOfferPrice);
         otherOffer.setTypeOfFood("Sushi");
-        otherOffer.setPicture(new byte[] { 0x44, -0x65, -0x4A, 0x2E });
+        otherOffer.setPicture(otherOfferPicture);
         entityManager.persist(otherOffer);
 
         // Flush all changes to the database

--- a/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferRepositoryTest.java
+++ b/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferRepositoryTest.java
@@ -7,14 +7,12 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 import java.util.List;
-import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 class CateringOfferRepositoryTest {
     private static final int PICTURE_ARRAY_SIZE = 5;
-    private final Random random = new Random();
 
     @Autowired
     private CateringOfferRepository cateringOfferRepository;
@@ -30,23 +28,19 @@ class CateringOfferRepositoryTest {
         company = entityManager.persistAndFlush(company);
 
         final double offer1Price = 12.99;
-        final byte[] offer1Picture = new byte[PICTURE_ARRAY_SIZE];
-        random.nextBytes(offer1Picture);
         CateringFoodEntity offer1 = new CateringFoodEntity();
         offer1.setCompany(company);
         offer1.setPrice(offer1Price);
         offer1.setTypeOfFood("Pizza");
-        offer1.setPicture(offer1Picture);
+        offer1.setPicture("abcd");
         entityManager.persist(offer1);
 
         final double offer2Price = 10.99;
-        final byte[] offer2Picture = new byte[PICTURE_ARRAY_SIZE];
-        random.nextBytes(offer2Picture);
         CateringFoodEntity offer2 = new CateringFoodEntity();
         offer2.setCompany(company);
         offer2.setPrice(offer2Price);
         offer2.setTypeOfFood("Burger");
-        offer2.setPicture(offer2Picture);
+        offer2.setPicture("dcba");
         entityManager.persist(offer2);
 
         // Another company with a different offer
@@ -55,13 +49,11 @@ class CateringOfferRepositoryTest {
         otherCompany = entityManager.persistAndFlush(otherCompany);
 
         final double otherOfferPrice = 8.99;
-        final byte[] otherOfferPicture = new byte[PICTURE_ARRAY_SIZE];
-        random.nextBytes(otherOfferPicture);
         CateringFoodEntity otherOffer = new CateringFoodEntity();
         otherOffer.setCompany(otherCompany);
         otherOffer.setPrice(otherOfferPrice);
         otherOffer.setTypeOfFood("Sushi");
-        otherOffer.setPicture(otherOfferPicture);
+        otherOffer.setPicture("xyz");
         entityManager.persist(otherOffer);
 
         // Flush all changes to the database

--- a/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferRepositoryTest.java
+++ b/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferRepositoryTest.java
@@ -31,6 +31,7 @@ class CateringOfferRepositoryTest {
         offer1.setCompany(company);
         offer1.setPrice(offer1Price);
         offer1.setTypeOfFood("Pizza");
+        offer1.setPicture(new byte[] { 0x00, 0x56, 0x24, -0x61 });
         entityManager.persist(offer1);
 
         final double offer2Price = 10.99;
@@ -38,6 +39,7 @@ class CateringOfferRepositoryTest {
         offer2.setCompany(company);
         offer2.setPrice(offer2Price);
         offer2.setTypeOfFood("Burger");
+        offer2.setPicture(new byte[] { 0x26, -0x12, -0x5F, 0x7F });
         entityManager.persist(offer2);
 
         // Another company with a different offer
@@ -50,6 +52,7 @@ class CateringOfferRepositoryTest {
         otherOffer.setCompany(otherCompany);
         otherOffer.setPrice(otherOfferPrice);
         otherOffer.setTypeOfFood("Sushi");
+        otherOffer.setPicture(new byte[] { 0x44, -0x65, -0x4A, 0x2E });
         entityManager.persist(otherOffer);
 
         // Flush all changes to the database

--- a/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImplTest.java
+++ b/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImplTest.java
@@ -2,6 +2,7 @@ package org.caterly.cateringcompanyservice.offer.domain;
 
 import org.caterly.cateringcompanyservice.company.domain.CateringCompanyEntity;
 import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferDTO;
+import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferRequestDTO;
 import org.caterly.cateringcompanyservice.offer.mapper.OfferMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,9 +11,7 @@ import org.mockito.Mock;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
@@ -49,18 +48,20 @@ class CateringOfferServiceImplTest {
         company1 = new CateringCompanyEntity(
                 COMPANY_1_ID, "San Francisco", List.of());
         offer1 = new CateringFoodEntity(
-                OFFER_1_ID, OFFER_1_PRICE, "Pizza", company1);
+                OFFER_1_ID, OFFER_1_PRICE, "Pizza", new byte[] { 0x00, 0x56, 0x24, -0x61 }, company1);
         offer2 = new CateringFoodEntity(
-                OFFER_2_ID, OFFER_2_PRICE, "Burger", company1);
+                OFFER_2_ID, OFFER_2_PRICE, "Burger", new byte[] { 0x26, -0x12, -0x5F, 0x7F }, company1);
 
         offerDTO1 = new CateringOfferDTO();
         offerDTO1.setId(OFFER_DTO_1_ID);
         offerDTO1.setPrice(OFFER_1_PRICE);
+        offerDTO1.setPicture(new byte[] { 0x00, 0x56, 0x24, -0x61 });
         offerDTO1.setTypeOfFood("Pizza");
 
         offerDTO2 = new CateringOfferDTO();
         offerDTO2.setId(OFFER_DTO_2_ID);
         offerDTO2.setPrice(OFFER_2_PRICE);
+        offerDTO2.setPicture(new byte[] { 0x26, -0x12, -0x5F, 0x7F });
         offerDTO2.setTypeOfFood("Burger");
     }
 
@@ -82,6 +83,8 @@ class CateringOfferServiceImplTest {
         assertEquals(2, result.size());
         assertEquals("Pizza", result.get(0).getTypeOfFood());
         assertEquals("Burger", result.get(1).getTypeOfFood());
+        assertArrayEquals(new byte[] { 0x00, 0x56, 0x24, -0x61 }, result.get(0).getPicture());
+        assertArrayEquals(new byte[] { 0x26, -0x12, -0x5F, 0x7F }, result.get(1).getPicture());
 
         // Verify interactions
         verify(cateringOfferRepository).findAllByCompanyId(1L);

--- a/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImplTest.java
+++ b/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImplTest.java
@@ -2,7 +2,6 @@ package org.caterly.cateringcompanyservice.offer.domain;
 
 import org.caterly.cateringcompanyservice.company.domain.CateringCompanyEntity;
 import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferDTO;
-import org.caterly.cateringcompanyservice.offer.api.dto.CateringOfferRequestDTO;
 import org.caterly.cateringcompanyservice.offer.mapper.OfferMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,21 +9,30 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import java.util.List;
+import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 class CateringOfferServiceImplTest {
+    private static final int PICTURE_ARRAY_SIZE = 5;
 
     private static final double OFFER_1_PRICE = 12.99;
+    private static final byte[] OFFER_1_PICTURE = new byte[PICTURE_ARRAY_SIZE];
     private static final double OFFER_2_PRICE = 10.99;
+    private static final byte[] OFFER_2_PICTURE = new byte[PICTURE_ARRAY_SIZE];
     private static final long COMPANY_1_ID = 1L;
     private static final long OFFER_1_ID = 1L;
     private static final long OFFER_2_ID = 2L;
     private static final long OFFER_DTO_1_ID = 1L;
     private static final long OFFER_DTO_2_ID = 2L;
+
+    private final Random random = new Random();
 
     @Mock
     private CateringOfferRepository cateringOfferRepository;
@@ -45,23 +53,26 @@ class CateringOfferServiceImplTest {
     void setUp() {
         openMocks(this);
 
+        random.nextBytes(OFFER_1_PICTURE);
+        random.nextBytes(OFFER_2_PICTURE);
+
         company1 = new CateringCompanyEntity(
                 COMPANY_1_ID, "San Francisco", List.of());
         offer1 = new CateringFoodEntity(
-                OFFER_1_ID, OFFER_1_PRICE, "Pizza", new byte[] { 0x00, 0x56, 0x24, -0x61 }, company1);
+                OFFER_1_ID, OFFER_1_PRICE, "Pizza", OFFER_1_PICTURE, company1);
         offer2 = new CateringFoodEntity(
-                OFFER_2_ID, OFFER_2_PRICE, "Burger", new byte[] { 0x26, -0x12, -0x5F, 0x7F }, company1);
+                OFFER_2_ID, OFFER_2_PRICE, "Burger", OFFER_2_PICTURE, company1);
 
         offerDTO1 = new CateringOfferDTO();
         offerDTO1.setId(OFFER_DTO_1_ID);
         offerDTO1.setPrice(OFFER_1_PRICE);
-        offerDTO1.setPicture(new byte[] { 0x00, 0x56, 0x24, -0x61 });
+        offerDTO1.setPicture(OFFER_1_PICTURE);
         offerDTO1.setTypeOfFood("Pizza");
 
         offerDTO2 = new CateringOfferDTO();
         offerDTO2.setId(OFFER_DTO_2_ID);
         offerDTO2.setPrice(OFFER_2_PRICE);
-        offerDTO2.setPicture(new byte[] { 0x26, -0x12, -0x5F, 0x7F });
+        offerDTO2.setPicture(OFFER_2_PICTURE);
         offerDTO2.setTypeOfFood("Burger");
     }
 
@@ -83,8 +94,8 @@ class CateringOfferServiceImplTest {
         assertEquals(2, result.size());
         assertEquals("Pizza", result.get(0).getTypeOfFood());
         assertEquals("Burger", result.get(1).getTypeOfFood());
-        assertArrayEquals(new byte[] { 0x00, 0x56, 0x24, -0x61 }, result.get(0).getPicture());
-        assertArrayEquals(new byte[] { 0x26, -0x12, -0x5F, 0x7F }, result.get(1).getPicture());
+        assertArrayEquals(OFFER_1_PICTURE, result.get(0).getPicture());
+        assertArrayEquals(OFFER_2_PICTURE, result.get(1).getPicture());
 
         // Verify interactions
         verify(cateringOfferRepository).findAllByCompanyId(1L);

--- a/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImplTest.java
+++ b/backend/cateringCompanyService/src/test/java/org/caterly/cateringcompanyservice/offer/domain/CateringOfferServiceImplTest.java
@@ -9,9 +9,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import java.util.List;
-import java.util.Random;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,19 +17,13 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 class CateringOfferServiceImplTest {
-    private static final int PICTURE_ARRAY_SIZE = 5;
-
     private static final double OFFER_1_PRICE = 12.99;
-    private static final byte[] OFFER_1_PICTURE = new byte[PICTURE_ARRAY_SIZE];
     private static final double OFFER_2_PRICE = 10.99;
-    private static final byte[] OFFER_2_PICTURE = new byte[PICTURE_ARRAY_SIZE];
     private static final long COMPANY_1_ID = 1L;
     private static final long OFFER_1_ID = 1L;
     private static final long OFFER_2_ID = 2L;
     private static final long OFFER_DTO_1_ID = 1L;
     private static final long OFFER_DTO_2_ID = 2L;
-
-    private final Random random = new Random();
 
     @Mock
     private CateringOfferRepository cateringOfferRepository;
@@ -53,26 +44,23 @@ class CateringOfferServiceImplTest {
     void setUp() {
         openMocks(this);
 
-        random.nextBytes(OFFER_1_PICTURE);
-        random.nextBytes(OFFER_2_PICTURE);
-
         company1 = new CateringCompanyEntity(
                 COMPANY_1_ID, "San Francisco", List.of());
         offer1 = new CateringFoodEntity(
-                OFFER_1_ID, OFFER_1_PRICE, "Pizza", OFFER_1_PICTURE, company1);
+                OFFER_1_ID, OFFER_1_PRICE, "Pizza", "abcd", company1);
         offer2 = new CateringFoodEntity(
-                OFFER_2_ID, OFFER_2_PRICE, "Burger", OFFER_2_PICTURE, company1);
+                OFFER_2_ID, OFFER_2_PRICE, "Burger", "dcba", company1);
 
         offerDTO1 = new CateringOfferDTO();
         offerDTO1.setId(OFFER_DTO_1_ID);
         offerDTO1.setPrice(OFFER_1_PRICE);
-        offerDTO1.setPicture(OFFER_1_PICTURE);
+        offerDTO1.setPicture("abcd");
         offerDTO1.setTypeOfFood("Pizza");
 
         offerDTO2 = new CateringOfferDTO();
         offerDTO2.setId(OFFER_DTO_2_ID);
         offerDTO2.setPrice(OFFER_2_PRICE);
-        offerDTO2.setPicture(OFFER_2_PICTURE);
+        offerDTO2.setPicture("dcba");
         offerDTO2.setTypeOfFood("Burger");
     }
 
@@ -94,8 +82,8 @@ class CateringOfferServiceImplTest {
         assertEquals(2, result.size());
         assertEquals("Pizza", result.get(0).getTypeOfFood());
         assertEquals("Burger", result.get(1).getTypeOfFood());
-        assertArrayEquals(OFFER_1_PICTURE, result.get(0).getPicture());
-        assertArrayEquals(OFFER_2_PICTURE, result.get(1).getPicture());
+        assertEquals("abcd", result.get(0).getPicture());
+        assertEquals("dcba", result.get(1).getPicture());
 
         // Verify interactions
         verify(cateringOfferRepository).findAllByCompanyId(1L);

--- a/backend/flyway/sql/cateringCompany/V1__setup_database.sql
+++ b/backend/flyway/sql/cateringCompany/V1__setup_database.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS catering_food_entity (
     id SERIAL PRIMARY KEY,
     price NUMERIC(10, 2),
     type_of_food VARCHAR(255),
+    picture bytea,
 
     -- Foreign key to CateringCompanyEntity
     catering_company_id BIGINT REFERENCES catering_company_entity(id) ON DELETE CASCADE

--- a/backend/flyway/sql/cateringCompany/V1__setup_database.sql
+++ b/backend/flyway/sql/cateringCompany/V1__setup_database.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS catering_food_entity (
     id SERIAL PRIMARY KEY,
     price NUMERIC(10, 2),
     type_of_food VARCHAR(255),
-    picture bytea,
+    picture TEXT,
 
     -- Foreign key to CateringCompanyEntity
     catering_company_id BIGINT REFERENCES catering_company_entity(id) ON DELETE CASCADE


### PR DESCRIPTION
- Dodałem zmienną `picture` typu `byte[]` (obraz przechowywany w formacie base64) do `CateringFoodEntity` i `CateringOfferDTO` oraz kolumnę typu `bytea` w skrypcie SQL
- Dodałem nową klasę `CateringOfferRequestDTO` (różni się od `CateringOfferDTO` tym że nie posiada zmiennej id, ale za to ma zmienną companyId)
- Dodałem repozytorium dla `CateringCompanyEntity` (używane w OfferMapperze)
- Zmieniłem `OfferMapper` na abstract class żeby możliwe było dodanie metody pobierającej `CateringCompanyEntity` o danym `companyId` oraz dodałem metodę mapującą `CateringOfferRequestDTO` na `CateringFoodEntity`.
- Do `CateringOfferService` oraz do kontrolera `CateringOfferController` dodałem metody dodające posiłek.
- Zmodyfikowałem testy, żeby uwzględniały zmienną `picture` w `CateringFoodEntity`.